### PR TITLE
Rlt current user posts

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -4,6 +4,7 @@ import { Post } from "./post/PostDetail"
 import { CategoriesList } from "./categories/CategoriesList";
 import { PostList } from "./post/PostList"
 import { TagsList } from "./tags/TagsList";
+import { UserPostList } from "./user/UserPosts";
 
 export const ApplicationViews = () => {
   return (
@@ -21,6 +22,9 @@ export const ApplicationViews = () => {
       </Route>
       <Route exact path="/tags">
         <TagsList />
+      </Route>
+      <Route exact path="/my-posts">
+        < UserPostList/>
       </Route>
     </>
   );

--- a/src/components/auth/AuthManager.js
+++ b/src/components/auth/AuthManager.js
@@ -12,6 +12,7 @@ export const loginUser = (user) => {
   }).then(res => res.json())
 }
 
+
 export const registerUser = (newUser) => {
   return fetch("http://127.0.0.1:8088/register", {
     method: "POST",

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -53,6 +53,9 @@ export const NavBar = ({ token, setToken }) => {
               <Link to="/tags" className="navbar-item">
                 Tag Management
               </Link>
+              <Link to="/my-posts" className="navbar-item">
+                My Posts
+              </Link>
             </>
           ) : (
             ""

--- a/src/components/post/PostManager.js
+++ b/src/components/post/PostManager.js
@@ -1,6 +1,9 @@
 export const getPosts = () => {
   return fetch("http://localhost:8088/posts").then((res) => res.json());
 };
+export const getUserPosts = (id) => {
+  return fetch(`http://localhost:8088/users?user_id=${id}`).then((res) => res.json());
+};
 
 export const getSinglePost = (postId) => {
   return fetch(`http://localhost:8088/posts/${postId}`)

--- a/src/components/user/UserPosts.css
+++ b/src/components/user/UserPosts.css
@@ -12,3 +12,12 @@
 .user-post h3 {
     padding: .5em;
 }
+
+table, tr, td {
+    border: 1px solid black;
+    padding: .3em
+}
+
+a td {
+    border: none;
+}

--- a/src/components/user/UserPosts.css
+++ b/src/components/user/UserPosts.css
@@ -13,7 +13,7 @@
     padding: .5em;
 }
 
-table, tr, td {
+table, tr, td, th {
     border: 1px solid black;
     padding: .3em
 }

--- a/src/components/user/UserPosts.css
+++ b/src/components/user/UserPosts.css
@@ -1,0 +1,14 @@
+.user-posts {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid black;
+}
+.user-post {
+    display: flex;
+    flex-direction: row;
+    border: 1px solid black;
+}
+
+.user-post h3 {
+    padding: .5em;
+}

--- a/src/components/user/UserPosts.js
+++ b/src/components/user/UserPosts.js
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from "react";
+import { useHistory, Link } from "react-router-dom";
+import { getUserPosts } from "../post/PostManager";
+import "./UserPosts.css"
+export const UserPostList = () => {
+    const [posts, setPosts] = useState([]);
+    const history = useHistory();
+    
+    const userId = parseInt(localStorage.getItem('token'))
+    
+    useEffect(() => {
+        getUserPosts(userId).then((postData) => setPosts(postData));
+    }, []);
+
+    return (
+        <div style={{ margin: "0rem 3rem" }}>
+        <h1>My Posts</h1>
+
+
+        <article className="user-posts">
+            {posts.map((post) => {
+            return (
+                <section className="user-post" key={post.id}>
+                <Link to={`/posts/${post.id}`}>
+                    <h3>{post.title}</h3>
+                </Link>
+                    <h3>{post.user.username}</h3>
+                    <h3>{post.publication_date}</h3>
+                    <h3>{post.category.label}</h3>
+                    <h3>{post.tags}</h3>
+                </section>
+            );
+            })}
+        </article>
+        </div>
+    );
+    };

--- a/src/components/user/UserPosts.js
+++ b/src/components/user/UserPosts.js
@@ -18,19 +18,28 @@ export const UserPostList = () => {
 
 
         <article className="user-posts">
+            <table>
+                <tr>
+                    <th>Title</th>
+                    <th>Username</th>
+                    <th>Date</th>
+                    <th>Category</th>
+                    <th>Tags</th>
+                </tr>
             {posts.map((post) => {
             return (
-                <section className="user-post" key={post.id}>
-                <Link to={`/posts/${post.id}`}>
-                    <h3>{post.title}</h3>
-                </Link>
-                    <h3>{post.user.username}</h3>
-                    <h3>{post.publication_date}</h3>
-                    <h3>{post.category.label}</h3>
-                    <h3>{post.tags}</h3>
-                </section>
+                    <tr>
+                        <Link to={`/posts/${post.id}`}>
+                            <td>{post.title}</td>
+                        </Link>
+                        <td>{post.user.username}</td>
+                        <td>{post.publication_date}</td>
+                        <td>{post.category.label}</td>
+                        <td>{post.tags}</td>
+                    </tr>
             );
-            })}
+        })}
+        </table>
         </article>
         </div>
     );


### PR DESCRIPTION
Now when user click on my posts in the nav bar they will be redirected to a table list of all of only* the current users posts

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #44

## Type of change


- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


- [ ] fetch --all code
- [ ] run python server
- [ ] click in nav bar "my posts"
- [ ] see all current user's posts in a table

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
