### PR TITLE
Rlt edit post

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -6,6 +6,7 @@ import { PostList } from "./post/PostList"
 import { PostForm } from "./post/PostForm";
 import { TagsList } from "./tags/TagsList";
 import { UserPostList } from "./user/UserPosts";
+import { EditPost } from "./user/EditPost";
 
 export const ApplicationViews = () => {
   return (
@@ -29,6 +30,9 @@ export const ApplicationViews = () => {
       </Route>
       <Route exact path="/my-posts">
         < UserPostList/>
+      </Route>
+      <Route exact path="/edit/:postId(\d+)">
+        < EditPost/>
       </Route>
     </>
   );

--- a/src/components/post/PostManager.js
+++ b/src/components/post/PostManager.js
@@ -20,3 +20,12 @@ export const createPost = (body) => {
   })
       .then(response => response.json())
 }
+export const editPost = (body) => {
+  return fetch(`http://localhost:8088/posts/${body.id}`, {
+      method: "PUT",
+      headers: {
+          "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+  })
+}

--- a/src/components/user/EditPost.js
+++ b/src/components/user/EditPost.js
@@ -80,7 +80,7 @@ export const EditPost = () => {
                 </div>
                 <div className="publishForm_button">
                     <div className="control">
-                        <button className="publish_button" type="submit" onClick={handleSubmit}>Publish</button>
+                        <button className="publish_button" type="submit" onClick={handleSubmit}>Save</button>
                     </div>
                 </div>
             </form>

--- a/src/components/user/EditPost.js
+++ b/src/components/user/EditPost.js
@@ -1,0 +1,89 @@
+import React, { useState, useEffect } from "react";
+import { useHistory, useParams } from "react-router-dom";
+import { getCategories } from "../categories/CategoriesManager";
+import { editPost, getPosts, getSinglePost } from "../post/PostManager";
+import "../post/Post.css"
+
+
+export const EditPost = () => {
+    const [categories, setCategories] = useState([])
+    const history = useHistory()
+    const postId = useParams()
+    const [post, setPost] = useState({})
+
+    useEffect(
+        () => {
+            getCategories()
+                .then(data => setCategories(data))
+        }, []
+    )
+
+    useEffect(
+        () => {
+            getSinglePost(postId.postId)
+                .then(data => setPost(data))
+        }, []
+    )
+    
+
+    const changePostState = (event) => {
+        const newPost = Object.assign({}, post)
+        newPost[event.target.name] = event.target.value
+        setPost(newPost)
+    }
+
+    const handleSubmit = (e) => {
+        e.preventDefault()
+        const newPost = {
+            id: post.id,
+            user_id: parseInt(post.user_id),
+            category_id: parseInt(post.category_id),
+            title: post.title,
+            publication_date: post.publication_date,
+            content: post.content
+        }
+
+        editPost(newPost)
+            .then(getPosts)
+            .then(() => history.push(`/posts/${postId.postId}`))
+    }
+
+
+    return (
+        <section className="post_form_container">
+            <form className="post_form" >
+                <h1 className="formTitle">Edit Post</h1>
+                <div className="title_field">
+                    <div className="title_control">
+                        <input className="post_title" type="text" name="title" placeholder={post.title} value={post.title} onChange={changePostState} />
+                    </div>
+                </div>
+                <div className="field">
+                    <div className="control">
+                        <textarea className="post_content" type="text" name="content" placeholder="Article content" value={post.content} onChange={changePostState} />
+                    </div>
+                </div>
+                <div className="dropdown_container">
+                    <div className="control">
+                    <select className="category_dropdown"
+                        name="category_id"
+                        value={post.category_id}
+                        onChange={changePostState}>
+                            <option name="category_id" value="" >Select a category</option>
+                        {
+                            categories?.map((category, index) => {
+                                return <option key={index} name="category_id" value={category.id}>{category.label}</option>
+                            })
+                        }
+                    </select>
+                    </div>
+                </div>
+                <div className="publishForm_button">
+                    <div className="control">
+                        <button className="publish_button" type="submit" onClick={handleSubmit}>Publish</button>
+                    </div>
+                </div>
+            </form>
+        </section>
+    )
+}

--- a/src/components/user/UserPosts.js
+++ b/src/components/user/UserPosts.js
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from "react";
 import { useHistory, Link } from "react-router-dom";
 import { getUserPosts } from "../post/PostManager";
+import {BsFillPencilFill} from "react-icons/bs"
 import "./UserPosts.css"
 export const UserPostList = () => {
     const [posts, setPosts] = useState([]);
     const history = useHistory();
-    
     const userId = parseInt(localStorage.getItem('token'))
     
     useEffect(() => {
@@ -14,33 +14,30 @@ export const UserPostList = () => {
 
     return (
         <div style={{ margin: "0rem 3rem" }}>
-        <h1>My Posts</h1>
-
-
-        <article className="user-posts">
-            <table>
-                <tr>
-                    <th>Title</th>
-                    <th>Username</th>
-                    <th>Date</th>
-                    <th>Category</th>
-                    <th>Tags</th>
-                </tr>
-            {posts.map((post) => {
-            return (
+            <h1>My Posts</h1>
+            <article className="user-posts">
+                <table>
                     <tr>
-                        <Link to={`/posts/${post.id}`}>
-                            <td>{post.title}</td>
-                        </Link>
-                        <td>{post.user.username}</td>
-                        <td>{post.publication_date}</td>
-                        <td>{post.category.label}</td>
-                        <td>{post.tags}</td>
+                        <th>Title</th>
+                        <th>Username</th>
+                        <th>Date</th>
+                        <th>Category</th>
+                        <th>Tags</th>
                     </tr>
-            );
-        })}
-        </table>
-        </article>
+                {posts.map((post) => {
+                return (
+                        <tr>
+                            <Link className="edit" to={`/edit/${post.id}`}>{BsFillPencilFill()}</Link>
+                            <Link to={`/posts/${post.id}`}><td>{post.title}</td></Link>
+                            <td>{post.user.username}</td>
+                            <td>{post.publication_date}</td>
+                            <td>{post.category.label}</td>
+                            <td>{post.tags}</td>
+                        </tr>
+                    );
+                    })}
+                </table>
+            </article>
         </div>
     );
-    };
+};


### PR DESCRIPTION
When user clicks into their posts home page, they can click on the edit button which will take them to an editing screen. User can make edits and send them back to the API and they will then get redirected to the post details page.

Fix ticket # 43


- New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] pull code
- [ ] start server
- [ ] navigate to my posts in nav bar
- [ ] click on the edit button of any post
- [ ] make edit to post and click save
- [ ] user should be redirected to the post details page.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings